### PR TITLE
Update SBTransformAnimation.cs

### DIFF
--- a/StudioSB/Scenes/Animation/SBTransformAnimation.cs
+++ b/StudioSB/Scenes/Animation/SBTransformAnimation.cs
@@ -80,11 +80,9 @@ namespace StudioSB.Scenes.Animation
                 return Matrix4.Identity;
 
             // temp for less matrix calculations
-            Vector3 newPos = new Vector3(bone.X, bone.Y, bone.Z); ;
+            Vector3 newPos = new Vector3(bone.X, bone.Y, bone.Z);
             Vector3 newRot = new Vector3(bone.RX, bone.RY, bone.RZ);
             Vector3 newSca = bone.Scale;
-
-
 
             if (bone is SBHsdBone hsdBone)
             {
@@ -149,9 +147,9 @@ namespace StudioSB.Scenes.Animation
 
             temp.Scale = newSca;
             temp.Translation = newPos;
-            /*if (useQuatRotation)
+            if (useQuatRotation)
                 temp.RotationQuaternion = Quaternion.Slerp(q1, q2, (Frame - f1) / (f2 - f1));
-            else*/
+            else
                 temp.RotationEuler = newRot;
 
             return temp.Transform;


### PR DESCRIPTION
Uncomment necessary code in SBTransformAnimation.cs to fix animation bug.

I noticed a bug when loading a GNT4 animation into StudioSB:

![ggg](https://user-images.githubusercontent.com/63434788/78959109-cebaee00-7a9e-11ea-93e7-b08d8f02980c.PNG)

It looks like code was commented that shouldn't have been.