### PR TITLE
.NUMSHEXB Export - BoundingSphere and TrueName changes.

### DIFF
--- a/StudioSB/Scenes/Ultimate/Loaders/MESHEX_Loader.cs
+++ b/StudioSB/Scenes/Ultimate/Loaders/MESHEX_Loader.cs
@@ -104,9 +104,10 @@ namespace StudioSB.Scenes.Ultimate.Loaders
         /// <returns></returns>
         private static string GetTrueName(string name)
         {
-            if (name.EndsWith("_VIS"))
-                name = name.Substring(0, name.IndexOf("_VIS"));
-
+            if (name.Contains("_VIS_"))
+                name = name.Substring(0, name.IndexOf("_VIS_"));
+            if (name.Contains("_O_"))
+                name = name.Substring(0, name.IndexOf("_O_"));
             if (name.EndsWith("Shape"))
                 name = name.Substring(0, name.IndexOf("Shape"));
 

--- a/StudioSB/Scenes/Ultimate/Loaders/MESHEX_Loader.cs
+++ b/StudioSB/Scenes/Ultimate/Loaders/MESHEX_Loader.cs
@@ -52,8 +52,8 @@ namespace StudioSB.Scenes.Ultimate.Loaders
         }
 
         /// <summary>
-        /// For each mesh in meshes, we will consolidate the meshes of the same name into one single meshex entry
-        /// with a new bouunding sphere calculated to cover all the same-named meshes
+        /// For each mesh in meshes, we will add an entry to 'Entries'. However, all meshes of the same name will get consolidated into
+        /// one single 'MeshData' entry that contains a new bounding sphere that encapsulates all the same-named meshes
         /// </summary>
         public void AddAllMeshData(List<SBUltimateMesh> Meshes)
         {
@@ -73,7 +73,6 @@ namespace StudioSB.Scenes.Ultimate.Loaders
                 }
             }
 
-            int mesh_ex_index = 0;
             foreach (var unique_mesh_name in mesh_name_dict.Keys)
             {
                 List<SBUltimateMesh> mesh_list = mesh_name_dict[unique_mesh_name];
@@ -91,9 +90,13 @@ namespace StudioSB.Scenes.Ultimate.Loaders
                     BoundingSphere = group_sphere,
                     Name = unique_mesh_name,
                     TrueName = GetTrueName(unique_mesh_name)
-                });
-                Entries.Add(new EntryEx() { MeshExIndex = mesh_ex_index });
-                mesh_ex_index++;
+                });   
+            }
+
+            foreach (var mesh in Meshes)
+            {
+                var data_index = MeshData.FindIndex(e => e.Name.Equals(mesh.Name));
+                Entries.Add(new EntryEx() { MeshExIndex = data_index });
             }
         }
 

--- a/StudioSB/Scenes/Ultimate/Loaders/MESHEX_Loader.cs
+++ b/StudioSB/Scenes/Ultimate/Loaders/MESHEX_Loader.cs
@@ -47,8 +47,54 @@ namespace StudioSB.Scenes.Ultimate.Loaders
                     TrueName = GetTrueName(Name)
                 });
             }
-
+    
             Entries.Add(new EntryEx() { MeshExIndex = data });
+        }
+
+        /// <summary>
+        /// For each mesh in meshes, we will consolidate the meshes of the same name into one single meshex entry
+        /// with a new bouunding sphere calculated to cover all the same-named meshes
+        /// </summary>
+        public void AddAllMeshData(List<SBUltimateMesh> Meshes)
+        {
+            Dictionary<string, List<SBUltimateMesh>> mesh_name_dict = new Dictionary<string, List<SBUltimateMesh>>();
+            foreach (var mesh in Meshes)
+            {
+                List<SBUltimateMesh> mesh_list = new List<SBUltimateMesh>();
+                if (mesh_name_dict.TryGetValue(mesh.Name, out mesh_list))
+                {
+                    mesh_list.Add(mesh);
+                }
+                else
+                {
+                    List<SBUltimateMesh> new_mesh_list = new List<SBUltimateMesh>();
+                    new_mesh_list.Add(mesh);
+                    mesh_name_dict.Add(mesh.Name, new_mesh_list);
+                }
+            }
+
+            int mesh_ex_index = 0;
+            foreach (var unique_mesh_name in mesh_name_dict.Keys)
+            {
+                List<SBUltimateMesh> mesh_list = mesh_name_dict[unique_mesh_name];
+                List<Vector3> grouped_vertices = new List<Vector3>();
+                foreach (var mesh in mesh_list)
+                {
+                    foreach (var vertex in mesh.Vertices)
+                    {
+                        grouped_vertices.Add(vertex.Position0);
+                    }
+                }
+                BoundingSphere group_sphere = new BoundingSphere(grouped_vertices);
+                MeshData.Add(new MeshEX()
+                {
+                    BoundingSphere = group_sphere,
+                    Name = unique_mesh_name,
+                    TrueName = GetTrueName(unique_mesh_name)
+                });
+                Entries.Add(new EntryEx() { MeshExIndex = mesh_ex_index });
+                mesh_ex_index++;
+            }
         }
 
         /// <summary>

--- a/StudioSB/Scenes/Ultimate/Loaders/MESH_Loader.cs
+++ b/StudioSB/Scenes/Ultimate/Loaders/MESH_Loader.cs
@@ -416,12 +416,13 @@ namespace StudioSB.Scenes.Ultimate
 
             meshEX = new MESHEX_Loader();
             meshEX.AllBoundingSphere = new BoundingSphere(allVertices);
-
+            /*
             foreach(var m in model.Meshes)
             {
                 meshEX.AddMeshData(m.BoundingSphere, m.Name);
             }
-
+            */
+            meshEX.AddAllMeshData(model.Meshes);
             return meshFile;
         }
         


### PR DESCRIPTION
When multiple same-named objects get consolidated into one entry, adjusts calculations of bounding spheres to take into account all objects rather than just putting in the bounding sphere of the first object. Also fixes the naming scheme to properly prune _VIS_ from the objects name.